### PR TITLE
Upgrade Swagger to 0.1.36

### DIFF
--- a/NCS.DSS.Goal/NCS.DSS.Goal.csproj
+++ b/NCS.DSS.Goal/NCS.DSS.Goal.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />

--- a/NCS.DSS.Goals.Tests/NCS.DSS.Goal.Tests.csproj
+++ b/NCS.DSS.Goals.Tests/NCS.DSS.Goal.Tests.csproj
@@ -8,7 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />


### PR DESCRIPTION
1. Upgraded Swagger from 0.1.30 to 0.1.36 on Goal Project
2. Removed Swagger Packages from Goal.Tests Project as its not required. 